### PR TITLE
Add GitHub Skills extracurricular activity

### DIFF
--- a/src/app.py
+++ b/src/app.py
@@ -74,6 +74,12 @@ activities = {
         "schedule": "Fridays, 4:00 PM - 5:30 PM",
         "max_participants": 12,
         "participants": ["charlotte@mergington.edu", "henry@mergington.edu"]
+    },
+    "GitHub Skills": {
+        "description": "Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications",
+        "schedule": "Mondays and Thursdays, 3:30 PM - 5:00 PM",
+        "max_participants": 25,
+        "participants": []
     }
 }
 


### PR DESCRIPTION
## 🎯 Description

This PR adds the **GitHub Skills** activity to the extracurricular activities system, resolving the urgent issue reported by students.

## 🚨 Context

Students reported that the GitHub Skills activity, which was announced by the principal in the school assembly, was missing from the signup page. This activity is time-sensitive as registrations close by the end of this week.

## ✨ Changes Made

- Added "GitHub Skills" to the activities dictionary in `src/app.py`
- **Description**: Learn practical coding and collaboration skills with GitHub. Part of the GitHub Certifications program to help with college applications
- **Schedule**: Mondays and Thursdays, 3:30 PM - 5:00 PM
- **Capacity**: 25 students
- **Initial participants**: Empty list (ready for registrations)

## ✅ Testing

The activity will now:
- ✅ Appear in the activities list on the website
- ✅ Allow students to sign up via the existing signup functionality
- ✅ Support up to 25 students
- ✅ Display correct schedule and description

## 📝 Related Issue

Fixes #6 - 🚨 Missing Activity: GitHub Skills

## 🎓 Impact

- Students can now register for the GitHub Skills activity
- Supports the GitHub Certifications program initiative
- Helps students with college applications